### PR TITLE
Erasing

### DIFF
--- a/src/debug_operations.ipp
+++ b/src/debug_operations.ipp
@@ -38,6 +38,7 @@ bool TwoFourTree<K,C,A>::Node::validateRelationships() const {
 		allNodes.pop_front();
 		node = check.second;
 
+		// Check if the parent/child relationships are consistent
 		if (check.first != check.second->parent_) {
 			rc = false;
 			std::cout << "parent of [" << check.second->getString() << "] doesn't have correct parent.\n";
@@ -53,13 +54,47 @@ bool TwoFourTree<K,C,A>::Node::validateRelationships() const {
 				std::cout << check.second->parent_->getString() << "\n";
 		}
 
+		// verify the internal contents are sorted
+		for (int i=1; i < node->num_keys_; i++) {
+			if (node->keys_[i-1] > node->keys_[i]) {
+				rc = false;
+				std::cout << "node keys out of order! " << node->keys_[i-1] << " is left of " << node->keys_[i] << std::endl;
+				std::cout << *this << std::endl;
+			}
+		}
+
+		// Count the number of children in the node
+		// For N keys in a node there should be N+1 children (except for leaf nodes)
+		// Also check to make sure the children contain either bigger or smaller values,
+		// depending on which child it is
+		// While we're traversing we also add each child to the list of nodes to be traversed
 		int num_children = 0;
-		for (int i = 0; i < kMaxNumChildren; i++) {
+		for (int i = 0; i < node->num_keys_; i++) { // First N children should have values smaller than keys_[i]
 			if (node->children_[i]) {
+				const Node *child = node->children_[i].get();
+				if (child->keys_[child->num_keys_-1] > node->keys_[i]) {
+					rc = false;
+					std::cout << "child to left has key greater than key ("
+							<< child->keys_[child->num_keys_ - 1] << " > "
+							<< node->keys_[i] << ")\n";
+				}
 				allNodes.push_back(std::make_pair(node,node->children_[i].get()));
 				++num_children;
 			}
 		}
+		if (node->children_[node->num_keys_]) { // Last (Nth) child should have value bigger than keys_[max]
+			const Node *child = node->children_[node->num_keys_].get();
+			if (child->keys_[0] < node->keys_[node->num_keys_-1]){
+				rc = false;
+				std::cout << "rightmost child has key less than my key ("
+						<< child->keys_[0] << " < "
+						<< node->keys_[node->num_keys_-1] << ")\n";
+			}
+			allNodes.push_back(std::make_pair(node,child));
+			++num_children;
+		}
+
+		// verify correct number of children
 		if (!node->isLeaf() && num_children != node->num_keys_ + 1) {
 			std::cout << "number of keys and children mismatch.\n";
 			std::cout << "Node contents = [" << node->getString() << "], num_keys = " << node->num_keys_ << ", #children (" << num_children <<"): \n";

--- a/src/debug_operations.ipp
+++ b/src/debug_operations.ipp
@@ -54,7 +54,7 @@ bool TwoFourTree<K,C,A>::Node::validateRelationships() const {
 		}
 
 		int num_children = 0;
-		for (int i = 0; i < node->num_keys_+1; i++) {
+		for (int i = 0; i < kMaxNumChildren; i++) {
 			if (node->children_[i]) {
 				allNodes.push_back(std::make_pair(node,node->children_[i].get()));
 				++num_children;

--- a/src/debug_operations.ipp
+++ b/src/debug_operations.ipp
@@ -117,7 +117,7 @@ std::string TwoFourTree<K,C,A>::Node::getStringAll() const {
 		}
 
 		if (node == &null_node) {
-			ss << "null:";
+			ss << "_:";
 			continue;
 		}
 

--- a/src/debug_operations.ipp
+++ b/src/debug_operations.ipp
@@ -53,10 +53,21 @@ bool TwoFourTree<K,C,A>::Node::validateRelationships() const {
 				std::cout << check.second->parent_->getString() << "\n";
 		}
 
+		int num_children = 0;
 		for (int i = 0; i < node->num_keys_+1; i++) {
 			if (node->children_[i]) {
 				allNodes.push_back(std::make_pair(node,node->children_[i].get()));
+				++num_children;
 			}
+		}
+		if (!node->isLeaf() && num_children != node->num_keys_ + 1) {
+			std::cout << "number of keys and children mismatch.\n";
+			std::cout << "Node contents = [" << node->getString() << "], num_keys = " << node->num_keys_ << ", #children (" << num_children <<"): \n";
+			for (int i = 0; i < num_children; i++) {
+				std::cout << node->children_[i]->getString() << "   ";
+			}
+			std::cout << "\n";
+			rc = false;
 		}
 	} // end loop
 	return rc;

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -543,6 +543,7 @@ typename TwoFourTree<K,C,A>::Node* TwoFourTree<K,C,A>::Node::rightSibling() {
 	return parent_->children_[getMyChildIdx() + 1].get();
 }
 
+// TODO: cleanup, remove node_, start using the getMyChildIdx
 template<class Key, class C, class A>
 std::pair<const typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>::Node::getSuccessor(int to_index) const {
 	assert(0 <= to_index && to_index < num_keys_);
@@ -701,7 +702,6 @@ bool TwoFourTree<K,C,A>::Node::isLeaf() const {
 	return !children_[0];
 }
 
-
 template<class  K, class C, class A>
 bool TwoFourTree<K,C,A>::Node::containsKey (const K& k) {
 	for (int i=0; i < num_keys_; i++)
@@ -716,13 +716,19 @@ const typename TwoFourTree<K,C,A>::Node * TwoFourTree<K,C,A>::Node::getParent ()
 }
 
 template<class  K, class C, class A>
-std::pair<const typename TwoFourTree<K,C,A>::Node *, int> TwoFourTree<K,C,A>::Node::findLargest () const {
-	const Node * node = this;
-	while (!node->isLeaf()) {
-		node = node->children_[num_keys_].get(); // rightmost child
-		assert(node != nullptr);
-	}
-	return std::make_pair(node, node->num_keys_ - 1);
+typename TwoFourTree<K,C,A>::const_iterator TwoFourTree<K,C,A>::Node::getEndIter () const {
+	if (isLeaf())
+		return const_iterator(this, num_keys_);
+	else
+		return children_[num_keys_]->getEndIter(); // rightmost child
+}
+
+template<class  K, class C, class A>
+typename TwoFourTree<K,C,A>::const_iterator TwoFourTree<K,C,A>::Node::getBeginIter () const {
+	if (isLeaf())
+		return const_iterator(this, 0);
+	else
+		return children_[0]->getBeginIter(); // leftmost child
 }
 
 } /* namespace tft */

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -266,6 +266,8 @@ std::pair<const typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>
 	assert(this == root.get()); // for now...
 
 	auto r = findWithRemove(value); // returns the leaf node and index (which should be r.first->num_keys_-1 UNLESS value was already in leaf)
+	if (r.first == nullptr || r.second == -1) // doesn't exist
+		return r;
 	assert(r.first->isLeaf());
 	assert(r.first->num_keys_ > 1 || r.first == root.get());
 	r.first->extractValue(r.second);
@@ -319,7 +321,8 @@ std::pair<typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>::Node
 	assert (original_key_location.first == nullptr && original_key_location.second == -1);
 
 	original_key_location = std::make_pair(traverse_iter.first, traverse_iter.first->getKeyIndex(key));
-	assert(original_key_location.second != -1);
+	if (original_key_location.second == -1) // key doesn't exist
+		return std::make_pair(nullptr, -1);
 
 	// Now the key is found.
 	// We need to keep traversing until we get to the predecessor node

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -444,7 +444,7 @@ bool TwoFourTree<K,C,A>::Node::containsKey (const K& k) {
 }
 
 template<class  K, class C, class A>
-typename TwoFourTree<K,C,A>::Node * TwoFourTree<K,C,A>::Node::getParent () const {
+const typename TwoFourTree<K,C,A>::Node * TwoFourTree<K,C,A>::Node::getParent () const {
 	return parent_;
 }
 

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -292,7 +292,6 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 	assert(parent_ != nullptr); // every underflow path requires a parent
 	assert(isLeaf());
 
-	std::cerr << "IN PROGRESS " << __FUNCTION__ << '\n';
 	int my_idx = getMyChildIdx();
 
 	// case 1.2.1
@@ -301,10 +300,10 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 	// if right siblign has >=2 keys, removeRightRotate();
 	{
 		if (my_idx > 0 && parent_->children_[my_idx-1]->num_keys_ >= 2) {
-			return removeLeftRotate();
+			return removeClockwise();
 		}
 		if (my_idx < (parent_->num_keys_) && parent_->children_[my_idx+1]->num_keys_ >= 2) {
-			return removeRightRotate();
+			return removeCounterClockwise();
 		}
 	}
 
@@ -323,15 +322,31 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 }
 
 template<class K, class C, class A>
-std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeLeftRotate() {
-	std::cerr << "TODO " << __FUNCTION__ << '\n';
-	return std::make_pair(nullptr, 0); // TODO
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeClockwise() {
+	assert(num_keys_ == 1);
+
+	int my_idx = getMyChildIdx();
+	assert(my_idx > 0);
+
+	auto left = leftSibling();
+	keys_[0] = std::move(parent_->keys_[my_idx - 1]);
+	parent_->keys_[my_idx - 1] = left->extractValue(left->num_keys_ - 1);
+
+	return getSuccessor(0);
 }
 
 template<class K, class C, class A>
-std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeRightRotate() {
-	std::cerr << "TODO " << __FUNCTION__ << '\n';
-	return std::make_pair(nullptr, 0); // TODO
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeCounterClockwise() {
+	assert(num_keys_ == 1);
+
+	int my_idx = getMyChildIdx();
+	assert(my_idx < parent_->num_keys_);
+
+	auto right = rightSibling();
+	keys_[0] = std::move(parent_->keys_[my_idx]);
+	parent_->keys_[my_idx] = right->extractValue(0);
+
+	return getSuccessor(0);
 }
 
 template<class K, class C, class A>
@@ -355,6 +370,16 @@ int TwoFourTree<K,C,A>::Node::getMyChildIdx() const{
 	}
 	std::cerr << "Error: I am not my parents child!\n";
 	return -1;
+}
+
+template <class K, class C, class A>
+typename TwoFourTree<K,C,A>::Node* TwoFourTree<K,C,A>::Node::leftSibling() {
+	return parent_->children_[getMyChildIdx() - 1].get();
+}
+
+template <class K, class C, class A>
+typename TwoFourTree<K,C,A>::Node* TwoFourTree<K,C,A>::Node::rightSibling() {
+	return parent_->children_[getMyChildIdx() + 1].get();
 }
 
 template<class Key, class C, class A>

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -452,9 +452,6 @@ typename TwoFourTree<K,C,A>::Node * TwoFourTree<K,C,A>::Node::fusion() {
 		std::unique_ptr<Node> self = std::move(parent_->children_[my_idx]);
 		for (auto i = my_idx; i < parent_->num_keys_; i++) {
 			parent_->children_[i] = std::move(parent_->children_[i + 1]);
-		}
-
-		for (auto i = my_idx; i < parent_->num_keys_; i++) {
 			parent_->keys_[i-1] = std::move(parent_->keys_[i]);
 		}
 

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -247,7 +247,7 @@ void TwoFourTree<K,C,A>::Node::overflowRecursive (K&& key, std::unique_ptr<Node>
 
 template<class Key, class C, class A>
 Key TwoFourTree<Key,C,A>::Node::extractValue(int index) {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	assert(index >= 0 && index < num_keys_);
 	assert(isLeaf()); // do not call this on an internal node
 
@@ -263,7 +263,7 @@ Key TwoFourTree<Key,C,A>::Node::extractValue(int index) {
 
 template<class Key, class C, class A>
 std::pair<const typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>::Node::removeValue(int at_index){
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	assert(at_index >= 0 && at_index < num_keys_);
 
 	if (isLeaf()) {
@@ -275,7 +275,7 @@ std::pair<const typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeLeaf(int at_index) {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	if (num_keys_ > 1 || parent_ == nullptr) {
 		auto rc = getSuccessor(at_index);
 		extractValue(at_index);
@@ -287,7 +287,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeInternal(int at_index) {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	// swap key with predecessor key
 	// predecessor is always leaf
 	// call removeLeaf on predecessor
@@ -306,7 +306,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeUnderflow(int at_index) {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	assert(parent_ != nullptr); // every underflow path requires a parent
 	assert(isLeaf());
 
@@ -341,7 +341,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeClockwise() {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	assert(num_keys_ == 1);
 
 	int my_idx = getMyChildIdx();
@@ -356,7 +356,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeCounterClockwise() {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	assert(num_keys_ == 1);
 
 	int my_idx = getMyChildIdx();
@@ -371,7 +371,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeFusion() {
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	int my_idx = getMyChildIdx();
 	int parent_key_idx;
 
@@ -424,7 +424,7 @@ std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::No
 
 template<class K, class C, class A>
 std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeFusionHeightReduced(){ // maybe combine with removeFusion
-//	std::cout << __FUNCTION__ << ": ";
+	std::cout << __FUNCTION__ << ": ";
 	//	assert(parent_->parent_ == nullptr); // TODO: assertion fails
 	assert(isLeaf());
 	assert(parent_->num_keys_ == 1);

--- a/src/node_operations.ipp
+++ b/src/node_operations.ipp
@@ -247,16 +247,114 @@ void TwoFourTree<K,C,A>::Node::overflowRecursive (K&& key, std::unique_ptr<Node>
 
 template<class Key, class C, class A>
 Key TwoFourTree<Key,C,A>::Node::extractValue(int index) {
-	assert(index > 0 && index < num_keys_);
+	assert(index >= 0 && index < num_keys_);
 	assert(isLeaf()); // do not call this on an internal node
 
 	Key k = std::move(keys_[index]);
 
 	for (int i=index; i < num_keys_ - 1; i++)
-		keys_[i] = std::move(i+1);
+		keys_[i] = std::move(keys_[i+1]);
 
 	num_keys_--;
 	return std::move(k);
+}
+
+
+template<class Key, class C, class A>
+std::pair<const typename TwoFourTree<Key,C,A>::Node*, int>  TwoFourTree<Key,C,A>::Node::removeValue(int at_index){
+	assert(at_index >= 0 && at_index < num_keys_);
+
+	if (isLeaf()) {
+		return removeLeaf(at_index);
+	} else {
+		return removeInternal(at_index);
+	}
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeLeaf(int at_index) {
+	if (num_keys_ > 1 || parent_ == nullptr) {
+		extractValue(at_index);
+		return std::make_pair(this, at_index);
+	} else {
+		return removeUnderflow(at_index);
+	}
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeInternal(int at_index) {
+	std::cerr << "TODO " << __FUNCTION__ << '\n';
+	return std::make_pair(nullptr, 0); // TODO
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeUnderflow(int at_index) {
+	assert(parent_ != nullptr); // every underflow path requires a parent
+	assert(isLeaf());
+
+	std::cerr << "IN PROGRESS " << __FUNCTION__ << '\n';
+	int my_idx = getMyChildIdx();
+
+	// case 1.2.1
+	// try to transfer values from sibling/parent if sibling supports it
+	// if left sibling has >=2 keys, removeLeftRotate();
+	// if right siblign has >=2 keys, removeRightRotate();
+	{
+		if (my_idx > 0 && parent_->children_[my_idx-1]->num_keys_ >= 2) {
+			return removeLeftRotate();
+		}
+		if (my_idx < (parent_->num_keys_) && parent_->children_[my_idx+1]->num_keys_ >= 2) {
+			return removeRightRotate();
+		}
+	}
+
+	// case 1.2.2 -> both siblings have <2 keys
+	// if parent has >=2 keys, removeFusion();
+	if (parent_->num_keys_ >= 2){
+		return removeFusion();
+	}
+
+
+	// case 1.2.3
+	// parent must be root
+	// combine with sibling and parent
+	assert (parent_->parent_ == nullptr);
+	return removeFusionHeightReduced();
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeLeftRotate() {
+	std::cerr << "TODO " << __FUNCTION__ << '\n';
+	return std::make_pair(nullptr, 0); // TODO
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeRightRotate() {
+	std::cerr << "TODO " << __FUNCTION__ << '\n';
+	return std::make_pair(nullptr, 0); // TODO
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeFusion() {
+	std::cerr << "TODO " << __FUNCTION__ << '\n';
+	return std::make_pair(nullptr, 0); // TODO
+}
+
+template<class K, class C, class A>
+std::pair<const typename TwoFourTree<K,C,A>::Node*, int>  TwoFourTree<K,C,A>::Node::removeFusionHeightReduced(){ // maybe combine with removeFusion
+	std::cerr << "TODO!" << __FUNCTION__ << '\n';
+	return std::make_pair(nullptr, 0); // TODO
+}
+
+template <class K, class C, class A>
+int TwoFourTree<K,C,A>::Node::getMyChildIdx() const{
+	assert(parent_ != nullptr);
+	for (int i=0; i <= parent_->num_keys_; ++i) {
+		if (parent_->children_[i].get() == this)
+			return i;
+	}
+	std::cerr << "Error: I am not my parents child!\n";
+	return -1;
 }
 
 template<class Key, class C, class A>

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -327,7 +327,7 @@ public:
 		Node * rightSibling();
 
 		Node* makeThreeNode();
-		std::pair<Node*,bool> traverse_step(const Key& looking_for_key);
+		std::pair<Node*,int> traverse_step(const Key& looking_for_key);
 		int getKeyIndex(const Key& key);
 		Node* transferFromRight();
 		Node* transferFromLeft();

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -310,7 +310,6 @@ public:
 		// debug
 		void print() const;
 		void printAll() const;
-//		void printFromAsHighAsPossible() const;
 		std::string getString() const;
 		std::string getStringAll() const;
 		bool validateRelationships() const;
@@ -339,14 +338,6 @@ public:
 
 		Key extractValue(int index);
 		std::pair<Node*,int> findWithRemove(const Key& key);
-		std::pair<const Node*,int> remove(int at_index);
-		std::pair<const Node*,int> removeLeaf(int at_index);
-		std::pair<const Node*,int> removeInternal(int at_index);
-		std::pair<const Node*,int> removeUnderflow(int at_index);
-		std::pair<const Node*,int> removeClockwise();
-		std::pair<const Node*,int> removeCounterClockwise();
-		std::pair<const Node*,int> removeFusion();
-		std::pair<const Node*,int> removeFusionHeightReduced(); // maybe combine with removeFusion
 
 		std::pair<Node*, int> addValueOverflow(Key &&key, std::unique_ptr<Node> &root);
 

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -305,6 +305,7 @@ public:
 
 		// TODO: return a const Node*
 		std::pair<Node*, int> addValue(Key&& value, std::unique_ptr<Node> &root);
+		std::pair<const Node*, int> removeValue(int at_index);
 
 		// debug
 		void print() const;
@@ -320,7 +321,17 @@ public:
 	private:
 		std::pair<Node*, int> getSuccessor(int to_index);
 		std::pair<Node*, int> getPredecessor(int to_index);
+		int getMyChildIdx() const;
+
 		Key extractValue(int index);
+		std::pair<const Node*,int> removeLeaf(int at_index);
+		std::pair<const Node*,int> removeInternal(int at_index);
+		std::pair<const Node*,int> removeUnderflow(int at_index);
+		std::pair<const Node*,int> removeLeftRotate();
+		std::pair<const Node*,int> removeRightRotate();
+		std::pair<const Node*,int> removeFusion();
+		std::pair<const Node*,int> removeFusionHeightReduced(); // maybe combine with removeFusion
+
 		std::pair<Node*, int> addValueOverflow(Key &&key, std::unique_ptr<Node> &root);
 
 		explicit Node(Node *parent) :
@@ -436,6 +447,18 @@ typename TwoFourTree<K,C,A>::const_reverse_iterator TwoFourTree<K,C,A>::crend() 
 	return const_reverse_iterator(begin_iterator_);
 }
 
+
+template<class K, class C, class A>
+typename TwoFourTree<K,C,A>::iterator TwoFourTree<K,C,A>::erase(TwoFourTree::iterator pos){
+	Node * node = const_cast<Node*> (pos.node_); // this cast is safe, otherwise caller couldn't call this function
+	return iterator(node->removeValue(pos.idx_));
+}
+
+template<class K, class C, class A>
+typename TwoFourTree<K,C,A>::size_type TwoFourTree<K,C,A>::erase(const TwoFourTree::key_type &key){
+	erase(root_->findKey(key));
+	return 1; // TODO keep track of size and return it here
+}
 
 } // namespace tft
 

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -322,13 +322,15 @@ public:
 		std::pair<Node*, int> getSuccessor(int to_index);
 		std::pair<Node*, int> getPredecessor(int to_index);
 		int getMyChildIdx() const;
+		Node * leftSibling();
+		Node * rightSibling();
 
 		Key extractValue(int index);
 		std::pair<const Node*,int> removeLeaf(int at_index);
 		std::pair<const Node*,int> removeInternal(int at_index);
 		std::pair<const Node*,int> removeUnderflow(int at_index);
-		std::pair<const Node*,int> removeLeftRotate();
-		std::pair<const Node*,int> removeRightRotate();
+		std::pair<const Node*,int> removeClockwise();
+		std::pair<const Node*,int> removeCounterClockwise();
 		std::pair<const Node*,int> removeFusion();
 		std::pair<const Node*,int> removeFusionHeightReduced(); // maybe combine with removeFusion
 

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -305,11 +305,12 @@ public:
 
 		// TODO: return a const Node*
 		std::pair<Node*, int> addValue(Key&& value, std::unique_ptr<Node> &root);
-		std::pair<const Node*, int> removeValue(int at_index);
+		std::pair<const Node*, int> removeValue(const Key& value, std::unique_ptr<Node> &root);
 
 		// debug
 		void print() const;
 		void printAll() const;
+//		void printFromAsHighAsPossible() const;
 		std::string getString() const;
 		std::string getStringAll() const;
 		bool validateRelationships() const;
@@ -325,7 +326,20 @@ public:
 		Node * leftSibling();
 		Node * rightSibling();
 
+		Node* makeThreeNode();
+		std::pair<Node*,bool> traverse_step(const Key& looking_for_key);
+		int getKeyIndex(const Key& key);
+		Node* transferFromRight();
+		Node* transferFromLeft();
+		Node* fusion();
+		Node* shrink();
+
+
+
+
 		Key extractValue(int index);
+		std::pair<Node*,int> findWithRemove(const Key& key);
+		std::pair<const Node*,int> remove(int at_index);
 		std::pair<const Node*,int> removeLeaf(int at_index);
 		std::pair<const Node*,int> removeInternal(int at_index);
 		std::pair<const Node*,int> removeUnderflow(int at_index);
@@ -453,15 +467,12 @@ typename TwoFourTree<K,C,A>::const_reverse_iterator TwoFourTree<K,C,A>::crend() 
 template<class K, class C, class A>
 typename TwoFourTree<K,C,A>::iterator TwoFourTree<K,C,A>::erase(TwoFourTree::iterator pos){
 	Node * node = const_cast<Node*> (pos.node_); // this cast is safe, otherwise caller couldn't call this function
-	return iterator(node->removeValue(pos.idx_));
+	return iterator(root_->removeValue(*pos, root_)); // TODO: fix efficiency to get bottom value from iterator?
 }
 
 template<class K, class C, class A>
 typename TwoFourTree<K,C,A>::size_type TwoFourTree<K,C,A>::erase(const TwoFourTree::key_type &key){
-	auto it = find(key);
-	std::cout << "\nerasing " << key << " from " << it << std::endl;
-	erase(it);
-	std::cout << "\n";
+	root_->removeValue(key, root_);
 	return 1; // TODO keep track of size and return it here
 }
 

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -458,8 +458,21 @@ typename TwoFourTree<K,C,A>::iterator TwoFourTree<K,C,A>::erase(TwoFourTree::ite
 
 template<class K, class C, class A>
 typename TwoFourTree<K,C,A>::size_type TwoFourTree<K,C,A>::erase(const TwoFourTree::key_type &key){
-	erase(root_->findKey(key));
+	auto it = find(key);
+//	std::cout << "\nerasing " << key << " from " << it << std::endl;
+	erase(it);
+//	std::cout << "\n";
 	return 1; // TODO keep track of size and return it here
+}
+
+template<class K, class C, class A>
+typename TwoFourTree<K,C,A>::const_iterator TwoFourTree<K,C,A>::find(const K &key) const {
+	return const_iterator(root_->findKey(key));
+}
+
+template<class K, class C, class A>
+typename TwoFourTree<K,C,A>::const_iterator TwoFourTree<K,C,A>::find(const K &key) {
+	return const_iterator(root_->findKey(key));
 }
 
 } // namespace tft

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -294,18 +294,17 @@ public:
 		Node() = default;
 		bool isFull() const;
 		bool isLeaf() const;
-		Node* getParent() const;
+		const Node* getParent() const;
 		bool isLargestChild() const;
 		bool containsKey(const Key& k);
-		std::pair<Node*, int> findKey(const Key &key);
+		std::pair<Node*, int> findKey(const Key &key); // TODO: return const Node* or make private
 		std::pair<const Node*, int> findLargest() const;
 
 		std::pair<const Node*, int> getSuccessor(int to_index) const;
 		std::pair<const Node*, int> getPredecessor(int to_index) const;
 
+		// TODO: return a const Node*
 		std::pair<Node*, int> addValue(Key&& value, std::unique_ptr<Node> &root);
-		Key extractValue(int index);
-		std::pair<Node*, int> addValueOverflow(Key &&key, std::unique_ptr<Node> &root);
 
 		// debug
 		void print() const;
@@ -321,6 +320,8 @@ public:
 	private:
 		std::pair<Node*, int> getSuccessor(int to_index);
 		std::pair<Node*, int> getPredecessor(int to_index);
+		Key extractValue(int index);
+		std::pair<Node*, int> addValueOverflow(Key &&key, std::unique_ptr<Node> &root);
 
 		explicit Node(Node *parent) :
 				parent_(parent) {

--- a/src/tftree.hpp
+++ b/src/tftree.hpp
@@ -459,9 +459,9 @@ typename TwoFourTree<K,C,A>::iterator TwoFourTree<K,C,A>::erase(TwoFourTree::ite
 template<class K, class C, class A>
 typename TwoFourTree<K,C,A>::size_type TwoFourTree<K,C,A>::erase(const TwoFourTree::key_type &key){
 	auto it = find(key);
-//	std::cout << "\nerasing " << key << " from " << it << std::endl;
+	std::cout << "\nerasing " << key << " from " << it << std::endl;
 	erase(it);
-//	std::cout << "\n";
+	std::cout << "\n";
 	return 1; // TODO keep track of size and return it here
 }
 

--- a/test/TestClass.hpp
+++ b/test/TestClass.hpp
@@ -1,0 +1,50 @@
+/*
+ *  Filename:   TestClass.hpp
+ *
+ *  Created on:  Jun. 20, 2020
+ *      Author:  orhan
+ *
+ *  Description:
+ *
+ */
+
+#ifndef TEST_TESTCLASS_HPP_
+#define TEST_TESTCLASS_HPP_
+
+class IntWrapper {
+public:
+	IntWrapper(int j) : i(j){}
+	IntWrapper() : i(-1) {}
+	~IntWrapper() {
+		if (i == -1) {
+			std::cout << "unused ";
+		}
+		std::cout << "dtor: " << this << std::endl;
+	}
+	friend std::ostream& operator<< (std::ostream& os, const IntWrapper& f) {
+		os << f.i;
+		return os;
+	}
+	friend IntWrapper& operator+ (IntWrapper& lhs, const int& rhs) {
+		lhs.i += rhs;
+		return lhs;
+	}
+	friend bool operator==(const int& lhs, const IntWrapper& rhs) {
+		return lhs == rhs.i;
+	}
+	friend bool operator==(const IntWrapper& lhs, const int& rhs) {
+		return lhs.i == rhs;
+	}
+	friend bool operator==(const IntWrapper& lhs, const IntWrapper& rhs) {
+		return lhs.i == rhs.i;
+	}
+	friend bool operator<(const IntWrapper& lhs, const IntWrapper& rhs) {
+		return lhs.i < rhs.i;
+	}
+	friend bool operator>(const IntWrapper& lhs, const IntWrapper& rhs) {
+		return lhs.i > rhs.i;
+	}
+	int i;
+};
+
+#endif /* TEST_TESTCLASS_HPP_ */

--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -149,7 +149,7 @@ TEST_CASE( "Erase with parent fusion", "[erase][underflow][fusion]" ) {
  * (one parent and two children), removing a key from either child
  * should result in three nodes merging into one and two nodes being deleted
  */
-TEST_CASE( "Erase fuse all remaining nodes", "[erase][underflow][fusion][.]" ) {
+TEST_CASE( "Erase fuse all remaining nodes", "[erase][underflow][fusion]" ) {
 	tft::TwoFourTree<int> tree;
 	tree.insert(0);
 	tree.insert(1);
@@ -250,3 +250,18 @@ TEST_CASE( "Erase root values complex", "[erase][internal]" ) {
 	REQUIRE(tree.validate());
 }
 
+TEST_CASE( "Erase - sequential", "[erase][underflow]" ) {
+	const int numTests = 10;
+	tft::TwoFourTree<int> tree;
+
+	for (int i = 0; i < numTests; i++)
+		tree.insert(std::move(i));
+	tree.print();
+
+	for (int i = 0; i < numTests; i++) {
+		tree.erase(i);
+		REQUIRE(!tree.contains(i));
+	}
+
+	REQUIRE(tree.validate());
+}

--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -280,6 +280,19 @@ TEST_CASE( "Erase - sequential", "[erase][shrink]" ) {
 	REQUIRE(tree.validate());
 }
 
+TEST_CASE("Erase nonexistent", "[erase]") {
+	const int numTests = 10;
+	tft::TwoFourTree<int> tree;
+
+	for (int i = 0; i < numTests; i++)
+		tree.insert(std::move(i));
+
+	tree.erase(-1);
+	tree.erase(11);
+	tree.erase(5);
+	tree.erase(5);
+}
+
 /**
  * Stress test
  */

--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -65,7 +65,7 @@ TEST_CASE( "Erase single empty node", "[erase]" ) {
  *
  *  Should cause a clockwise rotation so 33 goes up and 52 goes down to the right
  */
-TEST_CASE( "Erase with clockwise rotation", "[erase]" ) {
+TEST_CASE( "Erase with clockwise rotation", "[erase][underflow]" ) {
 	tft::TwoFourTree<int> tree;
 	tree.insert(20);
 	tree.insert(52);
@@ -87,7 +87,7 @@ TEST_CASE( "Erase with clockwise rotation", "[erase]" ) {
  *
  *  Should cause a counterclockwise rotation so 52 goes down and to the left, 76 goes up
  */
-TEST_CASE( "Erase with counter clockwise rotation", "[erase]" ) {
+TEST_CASE( "Erase with counter clockwise rotation", "[erase][underflow]" ) {
 	tft::TwoFourTree<int> tree;
 	tree.insert(20);
 	tree.insert(52);
@@ -99,5 +99,48 @@ TEST_CASE( "Erase with counter clockwise rotation", "[erase]" ) {
 	CHECK(tree.contains(52));
 	CHECK(tree.contains(76));
 	CHECK(tree.contains(82));
+}
+
+/**
+ *  Remove 55 from this tree:
+ *       [ 52, 60 ]
+ *      /     |    \
+ *  [ 20 ]  [ 55 ] [ 76 ]
+ *
+ *  20, 52 and 55 should merge into one node then 55 will be removed
+ */
+TEST_CASE( "Erase with parent fusion", "[erase][underflow][fusion]" ) {
+	tft::TwoFourTree<int> tree;
+	tree.insert(20);
+	tree.insert(52);
+	tree.insert(55);
+	tree.insert(60);
+	tree.insert(76);
+
+	// insert and erase 80 to split the node and create the correct tree
+	tree.insert(80);
+	tree.erase(80);
+
+	SECTION("Overflow left") {
+		tree.erase(20);
+		CHECK(!tree.contains(20));
+		tree.insert(20); // so we can check en-masse at the end of the section
+	}
+	SECTION("Overflow middle") {
+		tree.erase(55);
+		CHECK(!tree.contains(55));
+		tree.insert(55); // so we can check en-masse at the end of the section
+	}
+	SECTION("Overflow right") {
+		tree.erase(76);
+		CHECK(!tree.contains(76));
+		tree.insert(76); // so we can check en-masse at the end of the section
+	}
+
+	CHECK(tree.contains(20));
+	CHECK(tree.contains(52));
+	CHECK(tree.contains(55));
+	CHECK(tree.contains(60));
+	CHECK(tree.contains(76));
 }
 

--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -56,10 +56,48 @@ TEST_CASE( "Erase single empty node", "[erase]" ) {
 	CHECK(!tree.contains(20));
 }
 
-TEST_CASE( "Erase with single underflow", "[erase]" ) {
+
+/**
+ *  Remove 76 from this tree:
+ *           [ 52 ]
+ *          /      \
+ *  [ 20, 33 ]     [ 76 ]
+ *
+ *  Should cause a clockwise rotation so 33 goes up and 52 goes down to the right
+ */
+TEST_CASE( "Erase with clockwise rotation", "[erase]" ) {
 	tft::TwoFourTree<int> tree;
 	tree.insert(20);
+	tree.insert(52);
+	tree.insert(76);
+	tree.insert(33);
+
+	tree.erase(76);
+	CHECK(!tree.contains(76));
+	CHECK(tree.contains(20));
+	CHECK(tree.contains(33));
+	CHECK(tree.contains(52));
+}
+
+/**
+ *  Remove 20 from this tree:
+ *       [ 52 ]
+ *      /      \
+ *  [ 20 ]     [ 76, 82 ]
+ *
+ *  Should cause a counterclockwise rotation so 52 goes down and to the left, 76 goes up
+ */
+TEST_CASE( "Erase with counter clockwise rotation", "[erase]" ) {
+	tft::TwoFourTree<int> tree;
+	tree.insert(20);
+	tree.insert(52);
+	tree.insert(76);
+	tree.insert(82);
+
 	tree.erase(20);
 	CHECK(!tree.contains(20));
+	CHECK(tree.contains(52));
+	CHECK(tree.contains(76));
+	CHECK(tree.contains(82));
 }
 

--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Filename:   test_erase.cpp
+ *
+ *  Created on: May 16, 2020
+ *      Author: orhan
+ *
+ *  Description:
+ * 		Testing the erasing functionality of the TwoFourTree
+ */
+
+#include "../src/tftree.hpp"
+#include "catch.hpp"
+
+#include <cstdlib>
+#include <vector>
+#include <unordered_set>
+#include <algorithm>
+#include <chrono>
+
+TEST_CASE( "Simple erase", "[erase]" ) {
+
+	tft::TwoFourTree<int> tree;
+	tree.insert(20);
+	tree.insert(30);
+	tree.insert(40);
+
+	SECTION("Remove first") {
+		tree.erase(20);
+		CHECK(!tree.contains(20));
+		tree.insert(20);
+	}
+	SECTION("Remove second") {
+		tree.erase(30);
+		CHECK(!tree.contains(30));
+		tree.insert(30);
+	}
+	SECTION("Remove third") {
+		tree.erase(40);
+		CHECK(!tree.contains(40));
+		tree.insert(40);
+	}
+	CHECK(tree.contains(20));
+	CHECK(tree.contains(30));
+	CHECK(tree.contains(40));
+
+	tree.erase(40);
+	tree.erase(30);
+	CHECK(!tree.contains(40));
+	CHECK(!tree.contains(30));
+}
+
+TEST_CASE( "Erase single empty node", "[erase]" ) {
+	tft::TwoFourTree<int> tree;
+	tree.insert(20);
+	tree.erase(20);
+	CHECK(!tree.contains(20));
+}
+
+TEST_CASE( "Erase with single underflow", "[erase]" ) {
+	tft::TwoFourTree<int> tree;
+	tree.insert(20);
+	tree.erase(20);
+	CHECK(!tree.contains(20));
+}
+

--- a/test/test_iterate.cpp
+++ b/test/test_iterate.cpp
@@ -129,6 +129,54 @@ TEST_CASE ("Iterate to multiple neighbours", "[iterate][insert]") {
 }
 
 /**
+ * Test the iterators after erasing values
+ */
+TEST_CASE("Iterate after erase", "[iterate][insert][erase]") {
+
+	const int num_tests = 10;
+	tft::TwoFourTree<int> tree;
+
+	for (int i = 0; i < num_tests; i++)
+		tree.insert(std::move(i));
+
+	SECTION("Valid iterators after begin removed") {
+		for (int i =0; i < num_tests-1; i++) {
+			tree.erase(i);
+			REQUIRE(tree.validate());
+			auto begin_iter = tree.begin();
+			auto find_first = tree.find((i+1));
+			CHECK(begin_iter == find_first);
+		}
+
+		tree.erase(num_tests-1);
+
+		CHECK(tree.begin() == tree.end());
+		CHECK(tree.rbegin() == tree.rend());
+	}
+
+	SECTION("Valid iterators after ending removed") {
+		for (int i=num_tests-1; i >0;  i--) {
+			tree.erase(i);
+			REQUIRE(tree.validate());
+
+			auto end_iter = tree.end();
+			REQUIRE(*(end_iter-1) == i-1);
+
+			auto rbegin_it = tree.rbegin();
+			REQUIRE(*rbegin_it == i-1);
+		}
+
+		auto end_iter = tree.end();
+		tree.erase(0);
+
+		CHECK(end_iter != tree.end());
+		CHECK(tree.end() == tree.begin());
+		CHECK(tree.rend() == tree.rbegin());
+	}
+
+}
+
+/**
  * Stress test
  */
 TEST_CASE( "Iterate to multiple neighbours and parents", "[iterate][insert]" ) {


### PR DESCRIPTION
Implemented erase/remove along with relevant test cases. This is very different from insertion/additions. Whereas insertion may cause cascaded overflows from the leaf node upwards, erasing may cause cascaded underflows that must be handled from the root downwards.