### PR TITLE
Minor renaming and test additions

### DIFF
--- a/test/test_erase.cpp
+++ b/test/test_erase.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <chrono>
 
-TEST_CASE( "Simple erase", "[erase]" ) {
+TEST_CASE( "Erase values in single node", "[erase]" ) {
 
 	tft::TwoFourTree<int> tree;
 	tree.insert(20);
@@ -49,7 +49,7 @@ TEST_CASE( "Simple erase", "[erase]" ) {
 	CHECK(!tree.contains(30));
 }
 
-TEST_CASE( "Erase single empty node", "[erase]" ) {
+TEST_CASE( "Erase last value in tree", "[erase]" ) {
 	tft::TwoFourTree<int> tree;
 	tree.insert(20);
 	tree.erase(20);
@@ -77,6 +77,8 @@ TEST_CASE( "Erase with transfer left", "[erase][transferFromLeft]" ) {
 	CHECK(tree.contains(20));
 	CHECK(tree.contains(33));
 	CHECK(tree.contains(52));
+
+	REQUIRE(tree.validate());
 }
 
 /**
@@ -99,6 +101,8 @@ TEST_CASE( "Erase transfer right", "[erase][transferFromRight]" ) {
 	CHECK(tree.contains(52));
 	CHECK(tree.contains(76));
 	CHECK(tree.contains(82));
+
+	REQUIRE(tree.validate());
 }
 
 /**
@@ -167,6 +171,8 @@ TEST_CASE( "Erase fusion", "[erase][fusion]" ) {
 		CHECK(tree.contains(76));
 		CHECK(tree.contains(80));
 	}
+
+	REQUIRE(tree.validate());
 }
 
 /**
@@ -206,6 +212,8 @@ TEST_CASE( "Erase fusion root", "[erase][fusion]" ) {
 	CHECK(tree.contains(0));
 	CHECK(tree.contains(1));
 	CHECK(tree.contains(2));
+
+	REQUIRE(tree.validate());
 }
 
 
@@ -219,7 +227,7 @@ TEST_CASE( "Erase fusion root", "[erase][fusion]" ) {
  *
  * Verify that erasing 30, 40 and 50 works
  */
-TEST_CASE( "Erase internal", "[erase][internal][swap]" ) {
+TEST_CASE( "Erase values in internal nodes", "[erase][internal][swap]" ) {
 	tft::TwoFourTree<int> tree;
 
 	// order is very important to get the specified tree
@@ -256,7 +264,7 @@ TEST_CASE( "Erase internal", "[erase][internal][swap]" ) {
 	REQUIRE(tree.validate());
 }
 
-TEST_CASE( "Erase - sequential", "[erase][shrink]" ) {
+TEST_CASE( "Erase multi level tree with shrink", "[erase][shrink]" ) {
 	const int numTests = 10;
 	tft::TwoFourTree<int> tree;
 
@@ -280,7 +288,7 @@ TEST_CASE( "Erase - sequential", "[erase][shrink]" ) {
 	REQUIRE(tree.validate());
 }
 
-TEST_CASE("Erase nonexistent", "[erase]") {
+TEST_CASE("Erase nonexistent value", "[erase]") {
 	const int numTests = 10;
 	tft::TwoFourTree<int> tree;
 
@@ -291,12 +299,14 @@ TEST_CASE("Erase nonexistent", "[erase]") {
 	tree.erase(11);
 	tree.erase(5);
 	tree.erase(5);
+
+	REQUIRE(tree.validate());
 }
 
 /**
  * Stress test
  */
-TEST_CASE( "Erase - stress test", "[erase][insert]" ) {
+TEST_CASE( "Erase - Stress test", "[erase][insert]" ) {
 
 	const int numTests = 50000;
 

--- a/test/test_insert.cpp
+++ b/test/test_insert.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <chrono>
 
-TEST_CASE( "Simple Insert", "[insert]" ) {
+TEST_CASE( "Insert single node", "[insert]" ) {
 
 	tft::TwoFourTree<int> tree;
 
@@ -34,6 +34,8 @@ TEST_CASE( "Simple Insert", "[insert]" ) {
 	CHECK(!tree.insert(30).second);
 	CHECK(!tree.insert(40).second);
 	CHECK(!tree.insert(20).second);
+
+	REQUIRE(tree.validate());
 }
 
 /**
@@ -82,6 +84,7 @@ TEST_CASE( "Insert with Single Overflow", "[insert][overflow]" ) {
 		REQUIRE(tree.contains(it));
 	}
 
+	REQUIRE(tree.validate());
 }
 
 
@@ -145,11 +148,10 @@ TEST_CASE( "Insert with Cascaded Overflow", "[insert][overflow]" ) {
 		REQUIRE(tree.contains(it));
 	}
 
-	// Verifies all children have correct parents
 	REQUIRE(tree.validate());
 }
 
-TEST_CASE( "Insert - Random add check", "[insert][overflow]" ) {
+TEST_CASE( "Insert - Stress test with random adds", "[insert][overflow]" ) {
 	const int numTests = 100000; // 100k
 	std::unordered_set<int> rands( numTests ); // need set to remove duplicates
 	for (int i = 0; i < numTests; i++)

--- a/test/test_iterate.cpp
+++ b/test/test_iterate.cpp
@@ -20,7 +20,7 @@
  * Used tree:
  *     [ 1, 2, 3 ]
  */
-TEST_CASE( "Simple Iterate", "[iterate][insert]" ) {
+TEST_CASE( "Iterate within a node", "[iterate][insert]" ) {
 
 	tft::TwoFourTree<int> tree;
 
@@ -133,7 +133,7 @@ TEST_CASE ("Iterate to multiple neighbours", "[iterate][insert]") {
  */
 TEST_CASE("Iterate after erase", "[iterate][insert][erase]") {
 
-	const int num_tests = 10;
+	const int num_tests = 5000;
 	tft::TwoFourTree<int> tree;
 
 	for (int i = 0; i < num_tests; i++)
@@ -142,7 +142,6 @@ TEST_CASE("Iterate after erase", "[iterate][insert][erase]") {
 	SECTION("Valid iterators after begin removed") {
 		for (int i =0; i < num_tests-1; i++) {
 			tree.erase(i);
-			REQUIRE(tree.validate());
 			auto begin_iter = tree.begin();
 			auto find_first = tree.find((i+1));
 			CHECK(begin_iter == find_first);
@@ -157,7 +156,6 @@ TEST_CASE("Iterate after erase", "[iterate][insert][erase]") {
 	SECTION("Valid iterators after ending removed") {
 		for (int i=num_tests-1; i >0;  i--) {
 			tree.erase(i);
-			REQUIRE(tree.validate());
 
 			auto end_iter = tree.end();
 			REQUIRE(*(end_iter-1) == i-1);
@@ -173,7 +171,6 @@ TEST_CASE("Iterate after erase", "[iterate][insert][erase]") {
 		CHECK(tree.end() == tree.begin());
 		CHECK(tree.rend() == tree.rbegin());
 	}
-
 }
 
 /**


### PR DESCRIPTION
Changed all insert tests to start with insert, erase tests to start with
erase, iterate tests to start with iterate.

Added tree.validate() calls at the end of some test cases